### PR TITLE
Combined dependency updates (2022-11-29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.2
+      - uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '3.1.x'
       - name: Pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v5.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: net
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.2
+      - uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '3.1.x'
 

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.0.2 to 3.0.3](https://github.com/javiertuya/visual-assert/pull/44)
- [Bump crazy-max/ghaction-import-gpg from 5.1.0 to 5.2.0](https://github.com/javiertuya/visual-assert/pull/43)
- [Bump NUnit3TestAdapter from 4.2.1 to 4.3.0 in /net](https://github.com/javiertuya/visual-assert/pull/45)