### PR TITLE
Combined dependency updates (2022-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.6.1
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.5.2 to 3.6.1](https://github.com/javiertuya/visual-assert/pull/47)
- [Bump Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.0 in /net](https://github.com/javiertuya/visual-assert/pull/49)
- [Bump NUnit3TestAdapter from 4.3.0 to 4.3.1 in /net](https://github.com/javiertuya/visual-assert/pull/48)