### PR TITLE
Combined dependency updates (2023-03-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.0
+        uses: mikepenz/action-junit-report@v3.7.5
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.5.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.0 to 3.7.5](https://github.com/javiertuya/visual-assert/pull/56)
- [Bump maven-javadoc-plugin from 3.4.1 to 3.5.0 in /java](https://github.com/javiertuya/visual-assert/pull/58)
- [Bump Microsoft.NET.Test.Sdk from 17.4.1 to 17.5.0 in /net](https://github.com/javiertuya/visual-assert/pull/55)
- [Bump NUnit3TestAdapter from 4.3.1 to 4.4.0 in /net](https://github.com/javiertuya/visual-assert/pull/57)