### PR TITLE
Combined dependency updates (2023-06-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@v5.3.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.3
+      - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: net
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.3
+      - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -117,7 +117,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
+			<version>2.12.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.0.3 to 3.2.0](https://github.com/javiertuya/visual-assert/pull/68)
- [Bump crazy-max/ghaction-import-gpg from 5.2.0 to 5.3.0](https://github.com/javiertuya/visual-assert/pull/66)
- [Bump mikepenz/action-junit-report from 3.7.6 to 3.7.7](https://github.com/javiertuya/visual-assert/pull/67)
- [Bump commons-io from 2.11.0 to 2.12.0 in /java](https://github.com/javiertuya/visual-assert/pull/71)
- [Bump maven-gpg-plugin from 3.0.1 to 3.1.0 in /java](https://github.com/javiertuya/visual-assert/pull/73)
- [Bump maven-source-plugin from 3.2.1 to 3.3.0 in /java](https://github.com/javiertuya/visual-assert/pull/74)
- [Bump maven-surefire-report-plugin from 3.0.0 to 3.1.0 in /java](https://github.com/javiertuya/visual-assert/pull/72)
- [Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 in /net](https://github.com/javiertuya/visual-assert/pull/69)
- [Bump NUnit3TestAdapter from 4.4.2 to 4.5.0 in /net](https://github.com/javiertuya/visual-assert/pull/70)