### PR TITLE
Combined dependency updates (2023-07-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.7
+        uses: mikepenz/action-junit-report@v3.7.8
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.1.0
+      - uses: javiertuya/branch-snapshots-action@v1.2.0
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.12.0</version>
+			<version>2.13.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     


### PR DESCRIPTION
Includes these updates:
- [Bump javiertuya/branch-snapshots-action from 1.1.0 to 1.2.0](https://github.com/javiertuya/visual-assert/pull/79)
- [Bump mikepenz/action-junit-report from 3.7.7 to 3.7.8](https://github.com/javiertuya/visual-assert/pull/78)
- [Bump commons-io from 2.12.0 to 2.13.0 in /java](https://github.com/javiertuya/visual-assert/pull/81)
- [Bump maven-surefire-report-plugin from 3.1.0 to 3.1.2 in /java](https://github.com/javiertuya/visual-assert/pull/82)
- [Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.3 in /net](https://github.com/javiertuya/visual-assert/pull/80)