### PR TITLE
Combined dependency updates (2023-11-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.14.0</version>
+			<version>2.15.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.1 to 4.0.3](https://github.com/javiertuya/visual-assert/pull/96)
- [Bump commons-io:commons-io from 2.14.0 to 2.15.0 in /java](https://github.com/javiertuya/visual-assert/pull/98)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.1.2 to 3.2.1 in /java](https://github.com/javiertuya/visual-assert/pull/97)