### PR TITLE
Combined dependency updates (2024-02-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.1.0
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.2.3</version>
+				<version>3.2.5</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.3 to 4.1.0](https://github.com/javiertuya/visual-assert/pull/116)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.2.3 to 3.2.5 in /java](https://github.com/javiertuya/visual-assert/pull/117)