### PR TITLE
Combined dependency updates (2024-05-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.2
+      - uses: javiertuya/branch-snapshots-action@v1.2.3
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.0</version>
+			<version>2.16.1</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.2</version>
+						<version>3.2.4</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/branch-snapshots-action from 1.2.2 to 1.2.3](https://github.com/javiertuya/visual-assert/pull/131)
- [Bump org.apache.maven.plugins:maven-source-plugin from 3.3.0 to 3.3.1 in /java](https://github.com/javiertuya/visual-assert/pull/130)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.2 to 3.2.4 in /java](https://github.com/javiertuya/visual-assert/pull/129)
- [Bump commons-io:commons-io from 2.16.0 to 2.16.1 in /java](https://github.com/javiertuya/visual-assert/pull/128)