### PR TITLE
Combined dependency updates (2024-07-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.2.2
+        uses: mikepenz/action-junit-report@v4.3.1
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.10.2</junit5.version>
+		<junit5.version>5.10.3</junit5.version>
 	</properties>
 
 	<dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.2.5</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 4.2.2 to 4.3.1](https://github.com/javiertuya/visual-assert/pull/140)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.2.5 to 3.3.0 in /java](https://github.com/javiertuya/visual-assert/pull/139)
- [Bump junit5.version from 5.10.2 to 5.10.3 in /java](https://github.com/javiertuya/visual-assert/pull/138)