### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.4</version>
+						<version>3.2.5</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.10.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.10.3</junit5.version>
+		<junit5.version>5.11.0</junit5.version>
 	</properties>
 
 	<dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
 
     <PackageReference Include="NUnit" Version="4.1.0" />
     

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
 
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Microsoft.NET.Test.Sdk from 17.10.0 to 17.11.0 in /net](https://github.com/javiertuya/visual-assert/pull/152)
- [Bump NUnit from 4.1.0 to 4.2.2 in /net](https://github.com/javiertuya/visual-assert/pull/151)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0 in /java](https://github.com/javiertuya/visual-assert/pull/150)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.3.1 to 3.5.0 in /java](https://github.com/javiertuya/visual-assert/pull/149)
- [Bump junit5.version from 5.10.3 to 5.11.0 in /java](https://github.com/javiertuya/visual-assert/pull/148)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5 in /java](https://github.com/javiertuya/visual-assert/pull/147)