### PR TITLE
Combined dependency updates (2024-10-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.11.0</junit5.version>
+		<junit5.version>5.11.1</junit5.version>
 	</properties>
 
 	<dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.5</version>
+						<version>3.2.7</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.0</version>
 		</dependency>
 	</dependencies>
 

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
     <PackageReference Include="NUnit" Version="4.2.2" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.7 in /java](https://github.com/javiertuya/visual-assert/pull/157)
- [Bump junit5.version from 5.11.0 to 5.11.1 in /java](https://github.com/javiertuya/visual-assert/pull/156)
- [Bump commons-io:commons-io from 2.16.1 to 2.17.0 in /java](https://github.com/javiertuya/visual-assert/pull/155)
- [Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 in /net](https://github.com/javiertuya/visual-assert/pull/154)