### PR TITLE
Combined dependency updates (2024-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.3.1
+        uses: mikepenz/action-junit-report@v5.1.0
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.17.0</version>
+			<version>2.18.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.1</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.5.2</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 
     <PackageReference Include="NUnit" Version="4.2.2" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.5.1 to 3.5.2 in /java](https://github.com/javiertuya/visual-assert/pull/169)
- [Bump commons-io:commons-io from 2.17.0 to 2.18.0 in /java](https://github.com/javiertuya/visual-assert/pull/168)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.10.1 to 3.11.1 in /java](https://github.com/javiertuya/visual-assert/pull/167)
- [Bump mikepenz/action-junit-report from 4.3.1 to 5.1.0](https://github.com/javiertuya/visual-assert/pull/166)
- [Bump Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0 in /net](https://github.com/javiertuya/visual-assert/pull/165)