### PR TITLE
Combined dependency updates (2025-07-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.0
+        uses: mikepenz/action-junit-report@v5.6.1
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.13.0</junit5.version>
+		<junit5.version>5.13.2</junit5.version>
 	</properties>
 
 	<dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -125,7 +125,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.7.0</version>
+						<version>0.8.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 
     <PackageReference Include="NUnit" Version="4.3.2" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.7.0 to 0.8.0 in /java](https://github.com/javiertuya/visual-assert/pull/201)
- [Bump mikepenz/action-junit-report from 5.6.0 to 5.6.1](https://github.com/javiertuya/visual-assert/pull/200)
- [Bump junit5.version from 5.13.0 to 5.13.2 in /java](https://github.com/javiertuya/visual-assert/pull/199)
- [Bump Microsoft.NET.Test.Sdk from 17.13.0 to 17.14.1](https://github.com/javiertuya/visual-assert/pull/198)