### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.1
+        uses: mikepenz/action-junit-report@v5.6.2
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,7 +136,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.7</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.19.0</version>
+			<version>2.20.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.13.2</junit5.version>
+		<junit5.version>5.13.4</junit5.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.6.1 to 5.6.2](https://github.com/javiertuya/visual-assert/pull/206)
- [Bump junit5.version from 5.13.2 to 5.13.4 in /java](https://github.com/javiertuya/visual-assert/pull/205)
- [Bump commons-io:commons-io from 2.19.0 to 2.20.0 in /java](https://github.com/javiertuya/visual-assert/pull/204)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8 in /java](https://github.com/javiertuya/visual-assert/pull/203)