### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with: # running setup-java again overwrites the settings.xml
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       #Official documentation seems incomplete. To avoid failure when importing key: 
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
@@ -49,7 +49,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v4.3.1
         with:
             dotnet-version: '8.0.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     #if: ${{ false }}  # disable for now
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:
@@ -56,7 +56,7 @@ jobs:
       checks: write
       packages: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v4.3.1
         with:
             dotnet-version: '8.0.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v5
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.11.3</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
   </ItemGroup>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="4.3.2" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit3TestAdapter from 5.0.0 to 5.1.0](https://github.com/javiertuya/visual-assert/pull/212)
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/visual-assert/pull/211)
- [Bump actions/setup-java from 4 to 5](https://github.com/javiertuya/visual-assert/pull/210)
- [Bump NUnit from 4.3.2 to 4.4.0](https://github.com/javiertuya/visual-assert/pull/209)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.2 to 3.11.3 in /java](https://github.com/javiertuya/visual-assert/pull/208)