### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-dotnet@v4.3.1
+      - uses: actions/setup-dotnet@v5.0.0
         with:
             dotnet-version: '8.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-dotnet@v4.3.1
+      - uses: actions/setup-dotnet@v5.0.0
         with:
             dotnet-version: '8.0.x'
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.4</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.3</version>
+				<version>3.12.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -125,7 +125,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.8.0</version>
+						<version>0.9.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.sonatype.central:central-publishing-maven-plugin from 0.8.0 to 0.9.0 in /java](https://github.com/javiertuya/visual-assert/pull/218)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.5.3 to 3.5.4 in /java](https://github.com/javiertuya/visual-assert/pull/217)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.3 to 3.12.0 in /java](https://github.com/javiertuya/visual-assert/pull/216)
- [Bump actions/setup-dotnet from 4.3.1 to 5.0.0](https://github.com/javiertuya/visual-assert/pull/214)