### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@v6.3.0
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
  
       - if: always()
         name: Publish test reports
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-java-files
           #working-directory does not work here
@@ -83,7 +83,7 @@ jobs:
 
       - if: always()
         name: Publish test reports files
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-net-files
           #working-directory does not work here

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: javiertuya/branch-snapshots-action@v1.2.3
+      - uses: javiertuya/branch-snapshots-action@v2.0.0
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.5.4</version>
+				<version>3.5.5</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.14.2</junit5.version>
+		<junit5.version>5.14.3</junit5.version>
 	</properties>
 
 	<dependencies>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 
-    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="NUnit" Version="4.4.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.4.0 to 4.5.0](https://github.com/javiertuya/visual-assert/pull/250)
- [Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.3.0](https://github.com/javiertuya/visual-assert/pull/249)
- [Bump mikepenz/action-junit-report from 6.2.0 to 6.3.0](https://github.com/javiertuya/visual-assert/pull/248)
- [Bump org.apache.maven.plugins:maven-surefire-report-plugin from 3.5.4 to 3.5.5 in /java](https://github.com/javiertuya/visual-assert/pull/247)
- [Bump javiertuya/branch-snapshots-action from 1.2.3 to 2.0.0](https://github.com/javiertuya/visual-assert/pull/246)
- [Bump actions/upload-artifact from 6 to 7](https://github.com/javiertuya/visual-assert/pull/245)
- [Bump junit5.version from 5.14.2 to 5.14.3 in /java](https://github.com/javiertuya/visual-assert/pull/244)