### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       #https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions
       #It requires export the private key with the armor option: gpg --output private.pgm --armor --export-secret-key <email>
       - name: Import GPG Key 
-        uses: crazy-max/ghaction-import-gpg@v6.3.0
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
         with:
           gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v5.1.0
+      - uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: '8.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       #prevents execute on pr or dependabot that fails with "Resource not accessible by integration" due to permissions
       - name: Publish test report
         if: ${{ always() && github.actor=='javiertuya' }} 
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: test-report-net
           #working-directory does not work here

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       
-      - uses: actions/setup-dotnet@v5.1.0
+      - uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: '8.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.3.0
+        uses: mikepenz/action-junit-report@v6.4.0
         with:
           check_name: test-report-java
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
-    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="4.5.0" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit3TestAdapter from 6.1.0 to 6.2.0](https://github.com/javiertuya/visual-assert/pull/257)
- [Bump NUnit from 4.5.0 to 4.5.1](https://github.com/javiertuya/visual-assert/pull/256)
- [Bump mikepenz/action-junit-report from 6.3.0 to 6.4.0](https://github.com/javiertuya/visual-assert/pull/255)
- [Bump crazy-max/ghaction-import-gpg from 6.3.0 to 7.0.0](https://github.com/javiertuya/visual-assert/pull/254)
- [Bump actions/setup-dotnet from 5.1.0 to 5.2.0](https://github.com/javiertuya/visual-assert/pull/253)
- [Bump dorny/test-reporter from 2 to 3](https://github.com/javiertuya/visual-assert/pull/252)