### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.21.0</version>
+			<version>2.22.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<junit.version>4.13.2</junit.version>
-		<junit5.version>5.14.3</junit5.version>
+		<junit5.version>5.14.4</junit5.version>
 	</properties>
 
 	<dependencies>

--- a/net/TestVisualAssert/TestVisualAssert.csproj
+++ b/net/TestVisualAssert/TestVisualAssert.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
     <PackageReference Include="NUnit" Version="4.5.1" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.5.1](https://github.com/javiertuya/visual-assert/pull/261)
- [Bump junit5.version from 5.14.3 to 5.14.4 in /java](https://github.com/javiertuya/visual-assert/pull/260)
- [Bump commons-io:commons-io from 2.21.0 to 2.22.0 in /java](https://github.com/javiertuya/visual-assert/pull/259)